### PR TITLE
Check if phone number has 10 digits along with country code

### DIFF
--- a/frontend/src/pages/LostForm.js
+++ b/frontend/src/pages/LostForm.js
@@ -43,8 +43,8 @@ const validate = (values) => {
 
   if (!values.phone) {
     errors.phone = "Required";
-  } else if (values.phone.length > 10) {
-    errors.phone = "Too Long!";
+  } else if (values.phone.length !== 14) {
+    errors.phone = "Invalid number";
   }
 
   if (!values.email) {


### PR DESCRIPTION
Solves issue #13 

The error checking conditions are changed to ensure that the country code and exactly 10 digits are provided as input.

![image](https://user-images.githubusercontent.com/75936174/217875804-6019fdb9-48dd-449a-8f29-2ee1415dfb05.png)

Numbers with more digits display error prompts

![image](https://user-images.githubusercontent.com/75936174/217875895-8c12ce7e-c6d9-4d58-94b4-39603e268155.png)

Numbers with less digits display error messages

![image](https://user-images.githubusercontent.com/75936174/217875937-013af867-9f10-4ce0-b325-27175db52df7.png)

